### PR TITLE
meson: Fix bug with blueprint and Vala

### DIFF
--- a/data/ui/meson.build
+++ b/data/ui/meson.build
@@ -6,15 +6,15 @@
 
 blueprint_sources = ['mainwindow.blp']
 
-blueprints = custom_target(
-    'blueprints',
+blueprints = custom_target('blueprints',
     input: files(blueprint_sources),
     output: '.',
-    command: [
-        find_program('blueprint-compiler'),
-        'batch-compile',
-        '@OUTPUT@',
-        '@CURRENT_SOURCE_DIR@',
-        '@INPUT@',
-    ],
+    command: [find_program('blueprint-compiler'), 'batch-compile', '@OUTDIR@', '@CURRENT_SOURCE_DIR@', '@INPUT@'],
+)
+
+# This is a temporary workaround to fix a bug with the Vala compiler
+blueprints_workaround = custom_target('blueprints_workaround',
+  input: blueprints,
+  output: 'blueprints_workaround.vala',
+  command: [find_program('touch'), '@OUTPUT@'],
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -49,7 +49,7 @@ dependencies = [
 
 executable(
     meson.project_name(),
-    sources,
+    [blueprints_workaround, sources],
     dependencies: dependencies,
     install: true,
 )


### PR DESCRIPTION
By adding a blueprint_workaround.vala file temporarily, Blueprint compiles first, fixing the race condition between blueprint-compiler and valac